### PR TITLE
CI: Split jobs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   build:
+    name: Build and Test
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -14,7 +15,13 @@ jobs:
       run: make
     - name: Test
       run: make test
-    - name: Install packaging dependencies
+  deb:
+    name: Debian Packaging
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install dependencies
       run: sudo apt-get -qq --no-install-recommends install debhelper devscripts lintian fakeroot
     - name: Build package
       run: |


### PR DESCRIPTION
Split into 'build' and 'deb', with the latter only running if the former
completes successfully.