### PR TITLE
CI: Upload package to aptly only on merge to master

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
+    - name: Dump Github context
+      env:
+        GITHUB_CONTEXT: ${{ toJson(github) }}
+      run: echo "$GITHUB_CONTEXT"
     - uses: actions/checkout@v2
     - name: Install dependencies
       run: sudo apt-get -qq --no-install-recommends install debhelper devscripts lintian fakeroot
@@ -34,6 +38,7 @@ jobs:
         name: debs
         path: ./debs/
     - name: Upload package to aptly
+      # if: github.event_name == 'pull_request' ...
       uses: ./.github/actions/aptly-upload-action
       with:
         path: ./debs/


### PR DESCRIPTION
We only want an upload to the aptly instance to trigger when a pull
request is merged to master, or on a push commit to master.