### PR TITLE
CI: Upload to Aptly only on push to master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,13 +32,13 @@ jobs:
         debuild -us -uc
         mkdir ./debs
         cp ../*.deb ./debs
-    - name: Upload package as artifact
+    - name: Upload package artifact
       uses: actions/upload-artifact@v1
       with:
         name: debs
         path: ./debs/
     - name: Upload package to aptly
-      # if: github.event_name == 'pull_request' .....
+      if: github.event_name == 'push' && github.ref == 'refs/heads/master'
       uses: ./.github/actions/aptly-upload-action
       with:
         path: ./debs/


### PR DESCRIPTION
2nd try. This appears to be the canonical way to do it.

We want the Aptly upload only to run on pushes or merges to the master
branch.

Merging a PR into master will always produce a subsequent push event
(and workflow run), so this should do what we want.